### PR TITLE
Fix buffer overflow in _cbor_value_copy_string

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -1293,6 +1293,7 @@ CborError _cbor_value_copy_string(const CborValue *value, void *buffer,
                                  size_t *buflen, CborValue *next)
 {
     bool copied_all;
+    size_t maxlen = *buflen;
     CborError err = iterate_string_chunks(value, (char*)buffer, buflen, &copied_all, next,
                                           buffer ? (IterateFunction) value->parser->d->cpy : iterate_noop);
     if (err) {
@@ -1303,7 +1304,7 @@ CborError _cbor_value_copy_string(const CborValue *value, void *buffer,
         return CborErrorOutOfMemory;
     }
 
-    if (buffer) {
+    if (buffer && *buflen < maxlen) {
         *((uint8_t *)buffer + *buflen) = '\0';
     }
 


### PR DESCRIPTION
The function is documented to only null-terminate when the buffer is big enough to allow it.  Both upstream intel/tinycbor and mynewt's version do this correctly.

See https://github.com/zephyrproject-rtos/zephyr/issues/19629 for details.