### PR TITLE
tinycbor: Porting cborencoder changes from apache/mynewt-core

### DIFF
--- a/include/tinycbor/cbor.h
+++ b/include/tinycbor/cbor.h
@@ -204,9 +204,13 @@ typedef enum CborError {
 
 CBOR_API const char *cbor_error_string(CborError error);
 
+struct cbor_iovec {
+    void   *iov_base;
+    size_t iov_len;
+};
+
 /* Encoder API */
-struct CborEncoder
-{
+struct CborEncoder {
     cbor_encoder_writer *writer;
     void *writer_arg;
 #ifndef CBOR_NO_DFLT_WRITER
@@ -233,6 +237,9 @@ CBOR_API CborError cbor_encode_text_string(CborEncoder *encoder, const char *str
 CBOR_INLINE_API CborError cbor_encode_text_stringz(CborEncoder *encoder, const char *string)
 { return cbor_encode_text_string(encoder, string, strlen(string)); }
 CBOR_API CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, size_t length);
+CBOR_API CborError cbor_encode_byte_iovec(CborEncoder *encoder,
+                                          const struct cbor_iovec iov[],
+                                          int iov_len);
 CBOR_API CborError cbor_encode_floating_point(CborEncoder *encoder, CborType fpType, const void *value);
 CBOR_INLINE_API int cbor_encode_bytes_written(CborEncoder *encoder)
 {   return encoder->writer->bytes_written; }
@@ -252,6 +259,8 @@ CBOR_INLINE_API CborError cbor_encode_double(CborEncoder *encoder, double value)
 
 CBOR_API CborError cbor_encoder_create_array(CborEncoder *encoder, CborEncoder *arrayEncoder, size_t length);
 CBOR_API CborError cbor_encoder_create_map(CborEncoder *encoder, CborEncoder *mapEncoder, size_t length);
+CBOR_API CborError cbor_encoder_create_indef_text_string(CborEncoder *encoder, CborEncoder *stringEncoder);
+CBOR_API CborError cbor_encoder_create_indef_byte_string(CborEncoder *encoder, CborEncoder *stringEncoder);
 CBOR_API CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *containerEncoder);
 CBOR_API CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborEncoder *containerEncoder);
 


### PR DESCRIPTION
This is import of non-conflicting code.

Following commits have been partially or wholly ported from
apache/mynewt-core:
431df8afadd30 by Marko Kiiskila <marko@runtime.io>
05d4d80556e5e by Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>
b9e9544ec3c0e by Christopher Collins <ccollins@apache.org>

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>