### PR TITLE
zephyr: Moving cborinternal_p.h to cborconstants_p.h

### DIFF
--- a/include/tinycbor/cborconstants_p.h
+++ b/include/tinycbor/cborconstants_p.h
@@ -22,10 +22,8 @@
 **
 ****************************************************************************/
 
-#ifndef CBORINTERNAL_P_H
-#define CBORINTERNAL_P_H
-
-#include "tinycbor/compilersupport_p.h"
+#ifndef CBORCONSTANTS_P_H
+#define CBORCONSTANTS_P_H
 
 #ifndef CBOR_INTERNAL_API
 #  define CBOR_INTERNAL_API
@@ -86,4 +84,4 @@ enum {
 CBOR_INTERNAL_API CBOR_INTERNAL_API_CC CborError _cbor_value_extract_number(const CborParser *p, int *offset, uint64_t *len);
 CBOR_INTERNAL_API CBOR_INTERNAL_API_CC CborError _cbor_value_prepare_string_iteration(CborValue *it);
 
-#endif /* CBORINTERNAL_P_H */
+#endif /* CBORCONSTANTS_P_H */

--- a/include/tinycbor/extract_number_p.h
+++ b/include/tinycbor/extract_number_p.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+**
+** Copyright (C) 2015 Intel Corporation
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+** THE SOFTWARE.
+**
+****************************************************************************/
+
+#include "cbor.h"
+#include "cborconstants_p.h"
+#include "compilersupport_p.h"
+
+static inline uint16_t get16(const uint8_t *ptr)
+{
+    uint16_t result;
+    memcpy(&result, ptr, sizeof(result));
+    return cbor_ntohs(result);
+}
+
+static inline uint32_t get32(const uint8_t *ptr)
+{
+    uint32_t result;
+    memcpy(&result, ptr, sizeof(result));
+    return cbor_ntohl(result);
+}
+
+static inline uint64_t get64(const uint8_t *ptr)
+{
+    uint64_t result;
+    memcpy(&result, ptr, sizeof(result));
+    return cbor_ntohll(result);
+}
+
+static inline CborError extract_number(const CborParser *p, int *offset, uint64_t *len)
+{
+    uint8_t additional_information = p->d->get8(p->d, *offset) & SmallValueMask;
+    ++*offset;
+    *len = 1;
+    if (additional_information < Value8Bit) {
+        *len = additional_information;
+        return CborNoError;
+    }
+    if (unlikely(additional_information > Value64Bit))
+        return CborErrorIllegalNumber;
+
+    size_t bytesNeeded = (size_t)(1 << (additional_information - Value8Bit));
+    if (unlikely(bytesNeeded > (size_t)(p->end - *offset))) {
+        return CborErrorUnexpectedEOF;
+    } else if (bytesNeeded == 1) {
+        *len = p->d->get8(p->d, *offset);
+    } else if (bytesNeeded == 2) {
+        *len =  p->d->get16(p->d, *offset);
+    } else if (bytesNeeded == 4) {
+        *len =  p->d->get32(p->d, *offset);
+    } else {
+        *len =  p->d->get64(p->d, *offset);
+    }
+    *offset += bytesNeeded;
+    return CborNoError;
+}
+

--- a/src/cbor_buf_reader.c
+++ b/src/cbor_buf_reader.c
@@ -24,44 +24,12 @@
 
 #include <tinycbor/cbor_buf_reader.h>
 #include <tinycbor/compilersupport_p.h>
+#include <tinycbor/extract_number_p.h>
 
 /**
  * \addtogroup CborParsing
  * @{
  */
-
-/**
- * Gets 16 bit unsigned value from the passed in ptr location, it also
- * converts it to host byte order
- */
-CBOR_INLINE_API uint16_t get16(const uint8_t *ptr)
-{
-    uint16_t result;
-    memcpy(&result, ptr, sizeof(result));
-    return cbor_ntohs(result);
-}
-
-/**
- * Gets 32 bit unsigned value from the passed in ptr location, it also
- * converts it to host byte order
- */
-CBOR_INLINE_API uint32_t get32(const uint8_t *ptr)
-{
-    uint32_t result;
-    memcpy(&result, ptr, sizeof(result));
-    return cbor_ntohl(result);
-}
-
-/**
- * Gets 64 bit unsigned value from the passed in ptr location, it also
- * converts it to host byte order
- */
-CBOR_INLINE_API uint64_t get64(const uint8_t *ptr)
-{
-    uint64_t result;
-    memcpy(&result, ptr, sizeof(result));
-    return cbor_ntohll(result);
-}
 
 /**
  * Gets a string chunk from the passed in ptr location

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -33,8 +33,8 @@
 #endif
 
 #include "tinycbor/cbor.h"
-#include "tinycbor/cborinternal_p.h"
 #include "tinycbor/compilersupport_p.h"
+#include "tinycbor/cborconstants_p.h"
 #include "tinycbor/cbor_buf_writer.h"
 
 #include <stdlib.h>

--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -33,8 +33,8 @@
 #endif
 
 #include "tinycbor/cbor.h"
-#include "tinycbor/cborinternal_p.h"
 #include "tinycbor/compilersupport_p.h"
+#include "tinycbor/cborconstants_p.h"
 
 #include <string.h>
 

--- a/src/cborpretty.c
+++ b/src/cborpretty.c
@@ -30,7 +30,7 @@
 
 #include "tinycbor/cbor.h"
 #include "tinycbor/compilersupport_p.h"
-#include "tinycbor/cborinternal_p.h"
+#include "tinycbor/cborconstants_p.h"
 #include "tinycbor/utf8_p.h"
 
 #include <inttypes.h>

--- a/src/cborvalidation.c
+++ b/src/cborvalidation.c
@@ -33,7 +33,7 @@
 #endif
 
 #include "tinycbor/cbor.h"
-#include "tinycbor/cborinternal_p.h"
+#include "tinycbor/cborconstants_p.h"
 #include "tinycbor/compilersupport_p.h"
 #include "tinycbor/utf8_p.h"
 


### PR DESCRIPTION
Renaming header files and correcting C code to reflect changes in
header names in pursuit of closer alignment to mynewt-core version
of TinyCBOR.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>