### PR TITLE
cborencoder: Add functions calculating size of encoded data

### DIFF
--- a/include/tinycbor/cbor.h
+++ b/include/tinycbor/cbor.h
@@ -243,6 +243,10 @@ CBOR_INLINE_API CborError cbor_encode_null(CborEncoder *encoder)
 CBOR_INLINE_API CborError cbor_encode_undefined(CborEncoder *encoder)
 { return cbor_encode_simple_value(encoder, CborUndefinedType & 0x1f); }
 
+CBOR_API size_t cbor_encode_int_get_size(uint64_t ui);
+CBOR_INLINE_API size_t cbor_encode_string_get_size(size_t s)
+{ return cbor_encode_int_get_size(s) + s; }
+
 CBOR_INLINE_API CborError cbor_encode_half_float(CborEncoder *encoder, const void *value)
 { return cbor_encode_floating_point(encoder, CborHalfFloatType, value); }
 CBOR_INLINE_API CborError cbor_encode_float(CborEncoder *encoder, float value)

--- a/src/cborencoder.c
+++ b/src/cborencoder.c
@@ -413,6 +413,31 @@ static CborError encode_string(CborEncoder *encoder, size_t length, uint8_t shif
 }
 
 /**
+ * Returns size in bytes it will take to encode \a ui.
+ *
+ */
+size_t cbor_encode_int_get_size(uint64_t ui)
+{
+       size_t s = 1;
+
+       if (ui >= Value8Bit) {
+               s += 1;
+	       if (ui > 0xffU) {
+		       s += 1;
+	       }
+	       if (ui > 0xffffU) {
+		       s += 2;
+	       }
+	       if (ui > 0xffffffffU) {
+		       s += 4;
+	       }
+       }
+
+       return s;
+}
+
+
+/**
  * \fn CborError cbor_encode_text_stringz(CborEncoder *encoder, const char *string)
  *
  * Appends the null-terminated text string \a string to the CBOR stream


### PR DESCRIPTION
The functions will allow to check how much space in encoded stream would
data take, given the value or input size, in case of encoding strings.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>