### PR TITLE
zephyr: Remove TINYCBOR from interface libraries

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,7 +1,6 @@
 if(CONFIG_TINYCBOR)
-zephyr_interface_library_named(TINYCBOR)
 
-target_include_directories(TINYCBOR INTERFACE ../include)
+zephyr_include_directories(../include)
 
 zephyr_library()
 zephyr_library_sources(
@@ -17,6 +16,4 @@ zephyr_library_sources_ifdef(
 zephyr_library_sources_ifdef(
     CONFIG_CBOR_PRETTY_PRINTING ../src/cborpretty.c)
 
-zephyr_library_link_libraries(TINYCBOR)
-target_link_libraries(TINYCBOR INTERFACE zephyr_interface)
 endif()


### PR DESCRIPTION
Incorrect cmake function has been used to include TinyCBOR library,
as a result cmake has not been adding include paths, for the library
headers, into compilation.

Fixes #23324

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>