### PR TITLE
module: Deprecate TinyCBOR

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,5 +1,8 @@
 if(CONFIG_TINYCBOR)
 
+message(WARNING "TinyCBOR is deprecated.
+Please use zcbor instead with CONFIG_ZCBOR.")
+
 zephyr_include_directories(../include)
 
 zephyr_library()


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/issues/40591 for
additional details.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>